### PR TITLE
Fix for invalid mySQL query when empty data array is passed as parameter.

### DIFF
--- a/model/rds/Storage.php
+++ b/model/rds/Storage.php
@@ -135,6 +135,10 @@ class Storage
      * @return boolean
      */
     protected function saveData(RdsRevision $revision, $data) {
+        if(empty($data)) {
+            return false;
+        }
+        
         $columns = array(self::DATA_REVISION, self::DATA_SUBJECT, self::DATA_PREDICATE, self::DATA_OBJECT, self::DATA_LANGUAGE);
         
         $multipleInsertQueryHelper = $this->persistence->getPlatForm()->getMultipleInsertsSqlQueryHelper();


### PR DESCRIPTION
Added a check for an empy '$data' parameter, which causes an invalid MySQL query to be built and executed. 

I had to implement this to get my unit tests, which rely on committing **oat\taoWorkspace\model\lockStrategy\LockSystem** objects, to work.