### PR TITLE
TAO-7830. Allow commit resources on behalf of given user instead of r…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'Data Revision Control',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '5.0.2',
+    'version' => '5.1.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
        'generis'         => '>=5.9.0',

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return array(
     'label' => 'Data Revision Control',
     'description' => '',
     'license' => 'GPL-2.0',
-    'version' => '5.0.1',
+    'version' => '5.0.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
        'generis'         => '>=5.9.0',

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return array(
     'author' => 'Open Assessment Technologies SA',
     'requires' => array(
        'generis'         => '>=5.9.0',
-	   'tao'             => '>=21.0.0',
+	   'tao'             => '>=31.0.0',
 	   'taoItems'        => '*',
 	   'taoTests'        => '*',
 	   'taoMediaManager' => '*'

--- a/model/RepositoryService.php
+++ b/model/RepositoryService.php
@@ -90,10 +90,12 @@ class RepositoryService extends ConfigurableService implements Repository
      * (non-PHPdoc)
      * @see \oat\taoRevision\model\Repository::commit()
      */
-    public function commit($resourceId, $message, $version = null)
+    public function commit($resourceId, $message, $version = null, $userId = null)
     {
-        $user = \common_session_SessionManager::getSession()->getUser();
-        $userId = is_null($user) ? null : $user->getIdentifier();
+        if (!$userId) {
+            $user = \common_session_SessionManager::getSession()->getUser();
+            $userId = is_null($user) ? null : $user->getIdentifier();
+        }
         $version = is_null($version) ? $this->getNextVersion($resourceId) : $version;
         $created = time();
 

--- a/model/RepositoryService.php
+++ b/model/RepositoryService.php
@@ -92,7 +92,7 @@ class RepositoryService extends ConfigurableService implements Repository
      */
     public function commit($resourceId, $message, $version = null, $userId = null)
     {
-        if (!$userId) {
+        if ($userId === null) {
             $user = \common_session_SessionManager::getSession()->getUser();
             $userId = is_null($user) ? null : $user->getIdentifier();
         }

--- a/model/RevisionService.php
+++ b/model/RevisionService.php
@@ -1,21 +1,21 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
- * 
+ *
  */
 namespace oat\taoRevision\model;
 
@@ -28,18 +28,19 @@ use oat\oatbox\service\ServiceManager;
 class RevisionService
 {
     /**
-     * 
+     *
      * @param core_kernel_classes_Resource $resource
      * @param string $message
      * @param string $version
+     * @param string $userId owner of the resource
      * @deprecated
      * @return \oat\taoRevision\model\Revision
      */
-    static public function commit(core_kernel_classes_Resource $resource, $message, $version = null) {
-        
+    static public function commit(core_kernel_classes_Resource $resource, $message, $version = null, $userId = null)
+    {
         \common_Logger::w('Please register events to cause autocommits');
-        
+
         $repositoryService = ServiceManager::getServiceManager()->get(Repository::SERVICE_ID);
-        return $repositoryService->commit($resource->getUri(), $message, $version);
+        return $repositoryService->commit($resource->getUri(), $message, $version, $userId);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -90,6 +90,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.2.0');
         }
 
-        $this->skip('2.2.0', '5.0.1');
+        $this->skip('2.2.0', '5.0.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -90,6 +90,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('2.2.0');
         }
 
-        $this->skip('2.2.0', '5.0.2');
+        $this->skip('2.2.0', '5.1.0');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-7830

We cannot use sessions in the task queue, so this fix is to allow pass users from the outside.

One extra parameter (userId) says that commit() function shouldn't call SessionManager but use given userID instead.