### PR TITLE
Fix/render revisions without users

### DIFF
--- a/controller/History.php
+++ b/controller/History.php
@@ -75,10 +75,13 @@ class History extends tao_actions_CommonModule
 
         $revisionsList = [];
         foreach ($revisions as $revision) {
+            if ($author = $revision->getAuthorId()) {
+                $author = UserHelper::renderHtmlUser($revision->getAuthorId());
+            }
             $revisionsList[] = [
                 'id' => $revision->getVersion(),
                 'modified' => tao_helpers_Date::displayeDate($revision->getDateCreated()),
-                'author' => UserHelper::renderHtmlUser($revision->getAuthorId()),
+                'author' => $author,
                 'message' => tao_helpers_Display::htmlize($revision->getMessage()),
             ];
         }

--- a/manifest.php
+++ b/manifest.php
@@ -29,7 +29,7 @@ return [
     'label' => 'Data Revision Control',
     'description' => 'Allows saving the intermediate state of objects and restoring them',
     'license' => 'GPL-2.0',
-    'version' => '8.5.1',
+    'version' => '8.5.2',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'generis' => '>=12.15.0',

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -84,6 +84,6 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('8.0.0');
         }
-        $this->skip('8.0.0','8.5.1');
+        $this->skip('8.0.0','8.5.2');
     }
 }


### PR DESCRIPTION
When the author field is empty then we cannot generate author HTML for a history.