### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -16,7 +16,7 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             coverage: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,10 @@
     "oat-sa/extension-tao-itemqti" : ">=28.8.0",
     "oat-sa/extension-tao-test" : ">=15.0.0"
   },
+  "require-dev": {
+    "oat-sa/generis": "dev-php8-migration as v16.0.0",
+    "oat-sa/tao-core": "dev-php8-migration as v51.0.0"
+  },
   "autoload": {
     "psr-4": {
       "oat\\taoRevision\\": ""

--- a/composer.json
+++ b/composer.json
@@ -21,16 +21,12 @@
   "minimum-stability": "dev",
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "oat-sa/generis" : ">=14.0.0",
-    "oat-sa/tao-core" : ">=48.19.2",
+    "oat-sa/generis" : ">=15.22",
+    "oat-sa/tao-core" : ">=50.24.6",
     "oat-sa/extension-tao-item" : ">=11.8.0",
     "oat-sa/extension-tao-mediamanager" : ">=12.9.0",
     "oat-sa/extension-tao-itemqti" : ">=28.8.0",
     "oat-sa/extension-tao-test" : ">=15.0.0"
-  },
-  "require-dev": {
-    "oat-sa/generis": "dev-php8-migration as v16.0.0",
-    "oat-sa/tao-core": "dev-php8-migration as v51.0.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.