### PR TITLE
fix: align History action order for AUT-4491

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -5,7 +5,7 @@
         <sections>
             <section id="manage_items" name="Manage items" url="">
 				<actions>
-					<action id="item-revision" name="History" url="/taoRevision/History/index" context="instance" group="content">
+					<action id="item-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="9">
 					    <icon id="icon-repository"/>
 					</action>
 				</actions>
@@ -16,7 +16,7 @@
         <sections>
             <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                 <actions>
-					<action id="test-revision" name="History" url="/taoRevision/History/index" context="instance" group="content">
+					<action id="test-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="9">
 					    <icon id="icon-repository"/>
 					</action>
 				</actions>
@@ -27,7 +27,7 @@
         <sections>
             <section id="media_manager" name="Manage Media" url="/taoMediaManager/MediaManager/index">
                 <actions>
-					<action id="media-revision" name="History" url="/taoRevision/History/index" context="instance" group="content">
+					<action id="media-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="9">
 					    <icon id="icon-repository"/>
 					</action>
 				</actions>


### PR DESCRIPTION
## Summary
- set `History` content action weight to `9` in `controller/structures.xml` so it appears after other content actions
- align taoRevision tab ordering with AUT-4491 expected order after weight-based sorting
- keep the change isolated to configuration only (no PHP logic changes)

## Verification
- verified `tao/helpers/Layout.php` sorts actions by ascending weight
- with this change, order is now `Usage -> Item Statistics -> History`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system action prioritization weights to optimize the ordering and execution flow of application operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->