### PR TITLE
Develop

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -5,7 +5,7 @@
         <sections>
             <section id="manage_items" name="Manage items" url="">
 				<actions>
-					<action id="item-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="9">
+					<action id="item-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="4">
 					    <icon id="icon-repository"/>
 					</action>
 				</actions>
@@ -16,7 +16,7 @@
         <sections>
             <section id="manage_tests" name="Manage tests" url="/taoTests/Tests/index">
                 <actions>
-					<action id="test-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="9">
+					<action id="test-revision" name="History" url="/taoRevision/History/index" context="instance" group="content" weight="4">
 					    <icon id="icon-repository"/>
 					</action>
 				</actions>


### PR DESCRIPTION
## Summary

- Restore `History` action order in content tabs for Items and Tests.
- Align `taoRevision` action weight with AUT-4491 ordering used across extensions.

## Changes

- Updated `controller/structures.xml`:
  - `item-revision` weight changed from `9` to `4`.
  - `test-revision` weight changed from `9` to `4`.

## Why

- The previous weight placed `History` later than expected in the content action bar.
- This change restores the intended tab order for both Items and Tests.

## Testing

- Manual verification recommended in UI:
  - Open Item and Test editors.
  - Confirm `History` tab appears in expected order.

## Risk

- Low risk: configuration-only update in `structures.xml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the priority ordering of History actions in the content interface. History options for items and tests are now repositioned for improved visibility and accessibility alongside other available actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->